### PR TITLE
Makefile: remove default blocking target, simplify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,8 @@
-all:
-	:
-
 NAME := openinbrowser
 VERSION := $(shell grep em:version install.rdf|sed 's@.*em:version>\([^<]*\)<.*@\1@')
 TARGET_XPI = $(NAME)-$(VERSION).xpi
 
 xpi:
-	rm -rf ../tmp || :
-	mkdir ../tmp
-	cp -r ../$(NAME) ../tmp
-	rm -rf ../tmp/$(NAME)/.hg ../tmp/$(NAME)/.git ../tmp/$(NAME)/tests
-	find ../tmp -name "*~" -exec rm {} \;
-	cd ../tmp/$(NAME); \
-	zip -r $(TARGET_XPI) *
-	rm ../$(TARGET_XPI) || :
-	mv ../tmp/$(NAME)/$(TARGET_XPI) ..
-	rm -rf ../tmp
+	git archive --format zip -o $(TARGET_XPI) HEAD -- . ':!/tests/*'
+
+.PHONY: xpi

--- a/install.rdf
+++ b/install.rdf
@@ -6,7 +6,7 @@
 
     <em:id>openinbrowser@www.spasche.net</em:id>
     <em:name>Open in Browser</em:name>
-    <em:version>1.15</em:version>
+    <em:version>1.15-lkn</em:version>
     <em:type>2</em:type>
     <em:description>Offers the possibility to display documents in browser window.</em:description>
     <em:creator>Sylvain Pasche</em:creator>


### PR DESCRIPTION
Use git-archive to ignore untracked files. This however means that you
have to commit files before they end up in an xpi though,

Workflow (development):

    edit file
    git commit --amend -a
    make xpi
    # ... repeat process